### PR TITLE
Feat/use api key for requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # Zwei
+
+### Getting Started
+To build, gradle must be able to pull the XIVApi key. Currently it will pull from the variable `zwei_xivapi_key` inside the global gradle.properties file.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,9 +14,13 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
+        debug {
+            buildConfigField 'String', "XIVApiKey", zwei_xivapi_key
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            buildConfigField 'String', "XIVApiKey", zwei_xivapi_key
         }
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,12 +15,12 @@ android {
     }
     buildTypes {
         debug {
-            buildConfigField 'String', "XIVApiKey", zwei_xivapi_key
+            buildConfigField 'String', "XIVApiKey", System.getenv("zwei_xivapi_key") ?: zwei_xivapi_key
         }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            buildConfigField 'String', "XIVApiKey", zwei_xivapi_key
+            buildConfigField 'String', "XIVApiKey", System.getenv("zwei_xivapi_key") ?: zwei_xivapi_key
         }
     }
 }

--- a/app/src/main/java/com/chesire/zwei/xivapi/XIVApiManager.kt
+++ b/app/src/main/java/com/chesire/zwei/xivapi/XIVApiManager.kt
@@ -3,6 +3,7 @@ package com.chesire.zwei.xivapi
 import com.chesire.zwei.xivapi.adapters.GenderAdapter
 import com.chesire.zwei.xivapi.adapters.RaceAdapter
 import com.chesire.zwei.xivapi.adapters.StateAdapter
+import com.chesire.zwei.xivapi.interceptors.ApiKeyInterceptor
 import com.chesire.zwei.xivapi.interceptors.LanguageInterceptor
 import com.squareup.moshi.Moshi
 import okhttp3.OkHttpClient
@@ -13,21 +14,18 @@ import java.util.Locale
 
 private const val URL = "https://xivapi.com/"
 
-class XIVApiManager {
+class XIVApiManager(apiKey: String) {
     private val interact: XIVApiService
 
     init {
         val httpClient = OkHttpClient()
             .newBuilder()
 
-        //if (BuildConfig.DEBUG) {
-        val interceptor: HttpLoggingInterceptor = HttpLoggingInterceptor().apply {
-            this.level = HttpLoggingInterceptor.Level.BODY
-        }
-
-        httpClient.addInterceptor(interceptor)
+        httpClient.addInterceptor(HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        })
         httpClient.addInterceptor(LanguageInterceptor(Locale.getDefault().language))
-        //}
+        httpClient.addInterceptor(ApiKeyInterceptor(apiKey))
 
         val moshi = Moshi.Builder()
             .add(StateAdapter())

--- a/app/src/main/java/com/chesire/zwei/xivapi/interceptors/ApiKeyInterceptor.kt
+++ b/app/src/main/java/com/chesire/zwei/xivapi/interceptors/ApiKeyInterceptor.kt
@@ -6,7 +6,7 @@ import okhttp3.Response
 /**
  * Interceptor to insert the XIVApiKey `key=[apiKey]` into the query.
  *
- * Supported languages for XIVApi are documented at: https://xivapi.com/docs#section-4
+ * Documentation for the ApiKey can be found at: https://xivapi.com/docs#section-4
  */
 class ApiKeyInterceptor(private val apiKey: String) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {

--- a/app/src/main/java/com/chesire/zwei/xivapi/interceptors/ApiKeyInterceptor.kt
+++ b/app/src/main/java/com/chesire/zwei/xivapi/interceptors/ApiKeyInterceptor.kt
@@ -1,0 +1,25 @@
+package com.chesire.zwei.xivapi.interceptors
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * Interceptor to insert the XIVApiKey `key=[apiKey]` into the query.
+ *
+ * Supported languages for XIVApi are documented at: https://xivapi.com/docs#section-4
+ */
+class ApiKeyInterceptor(private val apiKey: String) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val original = chain.request()
+
+        val url = original.url()
+            .newBuilder()
+            .addQueryParameter("key", apiKey)
+            .build()
+
+        val request = original.newBuilder()
+            .url(url)
+            .build()
+        return chain.proceed(request)
+    }
+}

--- a/app/src/test/java/com/chesire/zwei/RealApiTests.kt
+++ b/app/src/test/java/com/chesire/zwei/RealApiTests.kt
@@ -17,7 +17,7 @@ class RealApiTests {
 
     @Before
     fun setup() {
-        manager = XIVApiManager()
+        manager = XIVApiManager("0000")
     }
 
     @After

--- a/app/src/test/java/com/chesire/zwei/xivapi/interceptors/ApiKeyInterceptorTests.kt
+++ b/app/src/test/java/com/chesire/zwei/xivapi/interceptors/ApiKeyInterceptorTests.kt
@@ -1,0 +1,49 @@
+package com.chesire.zwei.xivapi.interceptors
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class ApiKeyInterceptorTests {
+    private val mockWebServer = MockWebServer()
+
+    @Before
+    fun setup() {
+        mockWebServer.start()
+    }
+
+    @After
+    fun teardown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun `ensure adds key to requests`() {
+        mockWebServer.enqueue(MockResponse())
+
+        val okHttp = getOkHttpClient("0123456789abcdef")
+        sendMockRequest(okHttp)
+        val request = mockWebServer.takeRequest()
+
+        Assert.assertTrue(request.path.contains("key=0123456789abcdef"))
+    }
+
+    private fun getOkHttpClient(key: String): OkHttpClient {
+        return OkHttpClient().newBuilder()
+            .addInterceptor(ApiKeyInterceptor(key))
+            .build()
+    }
+
+    private fun sendMockRequest(okHttp: OkHttpClient) {
+        okHttp.newCall(
+            Request.Builder()
+                .url(mockWebServer.url("/"))
+                .build()
+        ).execute()
+    }
+}


### PR DESCRIPTION
Load the API key into all requests. It must be stored in the gradle.properties to be pushed into any builds