### PR TITLE
Test/change to use mockk

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,13 +53,13 @@ dependencies {
     implementation "com.google.dagger:dagger-android-support:$daggerVersion"
     implementation 'com.jakewharton.timber:timber:4.7.1'
     implementation 'com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:0.9.2'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.1.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.0'
     implementation 'com.squareup.retrofit2:retrofit:2.5.0'
     implementation 'com.squareup.retrofit2:converter-moshi:2.5.0'
     implementation 'com.squareup.okhttp3:logging-interceptor:3.11.0'
     implementation 'com.squareup.moshi:moshi:1.8.0'
     implementation 'com.vanniktech:lint-rules-android:0.8.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.1.1'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.1'
 
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.6.3'
     debugImplementation 'com.squareup.leakcanary:leakcanary-support-fragment:1.6.3'
@@ -69,6 +69,8 @@ dependencies {
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'io.mockk:mockk:1.9.kotlin12'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.1.1'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.1'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.0'
     androidTestImplementation 'androidx.test:rules:1.1.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,10 +66,9 @@ dependencies {
     releaseImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.6.3'
 
     testImplementation 'androidx.arch.core:core-testing:2.0.0'
-    testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.0.0'
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.23.0'
+    testImplementation 'io.mockk:mockk:1.9.kotlin12'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.0'
     androidTestImplementation 'androidx.test:rules:1.1.1'
@@ -83,6 +82,7 @@ dependencies {
         exclude group: 'org.jetbrains.kotlin'
     }
     androidTestImplementation 'org.mockito:mockito-android:2.22.0'
+    androidTestImplementation 'io.mockk:mockk-android:1.9.kotlin12'
 
     kapt 'androidx.lifecycle:lifecycle-compiler:2.0.0'
     kapt 'androidx.room:room-compiler:2.0.0'

--- a/app/src/androidTest/java/com/chesire/zwei/dagger/EspressoDaggerMockRule.kt
+++ b/app/src/androidTest/java/com/chesire/zwei/dagger/EspressoDaggerMockRule.kt
@@ -1,6 +1,6 @@
 package com.chesire.zwei.dagger
 
-import androidx.test.InstrumentationRegistry.getInstrumentation
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import com.chesire.zwei.MockApplication
 import com.chesire.zwei.dagger.components.MockComponent
 import com.chesire.zwei.dagger.modules.MockApplicationModule

--- a/app/src/androidTest/java/com/chesire/zwei/room/dao/CharacterDaoTests.kt
+++ b/app/src/androidTest/java/com/chesire/zwei/room/dao/CharacterDaoTests.kt
@@ -1,14 +1,16 @@
 package com.chesire.zwei.room.dao
 
 import androidx.room.Room
-import androidx.test.InstrumentationRegistry
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import com.chesire.zwei.room.ZweiDatabase
 import com.chesire.zwei.xivapi.flags.Gender
 import com.chesire.zwei.xivapi.flags.Race
 import com.chesire.zwei.xivapi.model.CharacterDetailModel
 import org.junit.After
 import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -20,7 +22,7 @@ class CharacterDaoTests {
     @Before
     fun setup() {
         db = Room.inMemoryDatabaseBuilder(
-            InstrumentationRegistry.getContext(),
+            InstrumentationRegistry.getInstrumentation().context,
             ZweiDatabase::class.java
         ).build()
     }
@@ -35,7 +37,7 @@ class CharacterDaoTests {
         val newModel = generateCharacterModel()
         db.characterDao().insert(newModel)
 
-        Assert.assertEquals(newModel, db.characterDao().get())
+        assertEquals(newModel, db.characterDao().get())
     }
 
     @Test
@@ -44,15 +46,15 @@ class CharacterDaoTests {
         val newModel2 = generateCharacterModel(0)
 
         db.characterDao().insert(newModel1)
-        Assert.assertEquals(newModel1, db.characterDao().get())
+        assertEquals(newModel1, db.characterDao().get())
 
         db.characterDao().insert(newModel2)
-        Assert.assertEquals(newModel2, db.characterDao().get())
+        assertEquals(newModel2, db.characterDao().get())
     }
 
     @Test
     fun retrievingCharacterWithoutSettingReturnsNull() {
-        Assert.assertNull(db.characterDao().get())
+        assertNull(db.characterDao().get())
     }
 
     @Test
@@ -60,9 +62,9 @@ class CharacterDaoTests {
         val newModel = generateCharacterModel()
         db.characterDao().insert(newModel)
 
-        Assert.assertEquals(newModel, db.characterDao().get())
+        assertEquals(newModel, db.characterDao().get())
         db.characterDao().delete(newModel)
-        Assert.assertNull(db.characterDao().get())
+        assertNull(db.characterDao().get())
     }
 
     private fun generateCharacterModel(id: Int = 0): CharacterDetailModel {

--- a/app/src/androidTest/java/com/chesire/zwei/room/dao/CharacterDaoTests.kt
+++ b/app/src/androidTest/java/com/chesire/zwei/room/dao/CharacterDaoTests.kt
@@ -8,7 +8,6 @@ import com.chesire.zwei.xivapi.flags.Gender
 import com.chesire.zwei.xivapi.flags.Race
 import com.chesire.zwei.xivapi.model.CharacterDetailModel
 import org.junit.After
-import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before

--- a/app/src/androidTest/java/com/chesire/zwei/room/dao/CompanionDaoTests.kt
+++ b/app/src/androidTest/java/com/chesire/zwei/room/dao/CompanionDaoTests.kt
@@ -1,12 +1,14 @@
 package com.chesire.zwei.room.dao
 
 import androidx.room.Room
-import androidx.test.InstrumentationRegistry
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import com.chesire.zwei.room.ZweiDatabase
 import com.chesire.zwei.xivapi.model.CompanionModel
 import org.junit.After
-import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,7 +20,7 @@ class CompanionDaoTests {
     @Before
     fun setup() {
         db = Room.inMemoryDatabaseBuilder(
-            InstrumentationRegistry.getContext(),
+            InstrumentationRegistry.getInstrumentation().context,
             ZweiDatabase::class.java
         ).build()
     }
@@ -33,7 +35,7 @@ class CompanionDaoTests {
         val newModel = generateCompanionModel(0)
         db.companionDao().insert(newModel)
 
-        Assert.assertTrue(db.companionDao().getAll().contains(newModel))
+        assertTrue(db.companionDao().getAll().contains(newModel))
     }
 
     @Test
@@ -45,12 +47,12 @@ class CompanionDaoTests {
         )
         db.companionDao().insertAll(models)
 
-        Assert.assertEquals(models, db.companionDao().getAll())
+        assertEquals(models, db.companionDao().getAll())
     }
 
     @Test
     fun findByIdWithNoMatchingCompanionsReturnsNull() {
-        Assert.assertNull(db.companionDao().findById(0))
+        assertNull(db.companionDao().findById(0))
     }
 
     @Test
@@ -63,17 +65,17 @@ class CompanionDaoTests {
         )
         db.companionDao().insertAll(models)
 
-        Assert.assertEquals(expectedModel, db.companionDao().findById(1))
+        assertEquals(expectedModel, db.companionDao().findById(1))
     }
 
     @Test
     fun getAllWithNoItemsReturnsEmptyList() {
-        Assert.assertTrue(db.companionDao().getAll().isEmpty())
+        assertTrue(db.companionDao().getAll().isEmpty())
     }
 
     @Test
     fun getAllWithIdsNoItemsReturnsEmptyList() {
-        Assert.assertTrue(db.companionDao().getAllByIds(listOf(0, 1, 2)).isEmpty())
+        assertTrue(db.companionDao().getAllByIds(listOf(0, 1, 2)).isEmpty())
     }
 
     @Test
@@ -84,7 +86,7 @@ class CompanionDaoTests {
             generateCompanionModel(2)
         )
         db.companionDao().insertAll(models)
-        Assert.assertTrue(db.companionDao().getAllByIds(listOf(0, 1, 3)).count() == 2)
+        assertTrue(db.companionDao().getAllByIds(listOf(0, 1, 3)).count() == 2)
     }
 
     @Test
@@ -95,7 +97,7 @@ class CompanionDaoTests {
             generateCompanionModel(2)
         )
         db.companionDao().insertAll(models)
-        Assert.assertEquals(models, db.companionDao().getAllByIds(listOf(0, 1, 2)))
+        assertEquals(models, db.companionDao().getAllByIds(listOf(0, 1, 2)))
     }
 
     private fun generateCompanionModel(

--- a/app/src/androidTest/java/com/chesire/zwei/room/dao/FreeCompanyDaoTests.kt
+++ b/app/src/androidTest/java/com/chesire/zwei/room/dao/FreeCompanyDaoTests.kt
@@ -1,13 +1,14 @@
 package com.chesire.zwei.room.dao
 
 import androidx.room.Room
-import androidx.test.InstrumentationRegistry
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import com.chesire.zwei.room.ZweiDatabase
 import com.chesire.zwei.xivapi.model.FreeCompanyEstateModel
 import com.chesire.zwei.xivapi.model.FreeCompanyModel
 import org.junit.After
-import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -19,7 +20,7 @@ class FreeCompanyDaoTests {
     @Before
     fun setup() {
         db = Room.inMemoryDatabaseBuilder(
-            InstrumentationRegistry.getContext(),
+            InstrumentationRegistry.getInstrumentation().context,
             ZweiDatabase::class.java
         ).build()
     }
@@ -34,7 +35,7 @@ class FreeCompanyDaoTests {
         val newModel = generateFreeCompanyModel(0)
         db.freeCompanyDao().insert(newModel)
 
-        Assert.assertEquals(newModel, db.freeCompanyDao().get())
+        assertEquals(newModel, db.freeCompanyDao().get())
     }
 
     @Test
@@ -43,15 +44,15 @@ class FreeCompanyDaoTests {
         val newModel2 = generateFreeCompanyModel(0)
 
         db.freeCompanyDao().insert(newModel1)
-        Assert.assertEquals(newModel1, db.freeCompanyDao().get())
+        assertEquals(newModel1, db.freeCompanyDao().get())
 
         db.freeCompanyDao().insert(newModel2)
-        Assert.assertEquals(newModel2, db.freeCompanyDao().get())
+        assertEquals(newModel2, db.freeCompanyDao().get())
     }
 
     @Test
     fun retrievingFreeCompanyWithoutSettingReturnsNull() {
-        Assert.assertNull(db.freeCompanyDao().get())
+        assertNull(db.freeCompanyDao().get())
     }
 
     @Test
@@ -59,9 +60,9 @@ class FreeCompanyDaoTests {
         val newModel = generateFreeCompanyModel(0)
         db.freeCompanyDao().insert(newModel)
 
-        Assert.assertEquals(newModel, db.freeCompanyDao().get())
+        assertEquals(newModel, db.freeCompanyDao().get())
         db.freeCompanyDao().delete(newModel)
-        Assert.assertNull(db.freeCompanyDao().get())
+        assertNull(db.freeCompanyDao().get())
     }
 
     private fun generateFreeCompanyModel(id: Int): FreeCompanyModel {

--- a/app/src/androidTest/java/com/chesire/zwei/room/dao/MountDaoTests.kt
+++ b/app/src/androidTest/java/com/chesire/zwei/room/dao/MountDaoTests.kt
@@ -1,12 +1,14 @@
 package com.chesire.zwei.room.dao
 
 import androidx.room.Room
-import androidx.test.InstrumentationRegistry
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import com.chesire.zwei.room.ZweiDatabase
 import com.chesire.zwei.xivapi.model.MountModel
 import org.junit.After
-import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,7 +20,7 @@ class MountDaoTests {
     @Before
     fun setup() {
         db = Room.inMemoryDatabaseBuilder(
-            InstrumentationRegistry.getContext(),
+            InstrumentationRegistry.getInstrumentation().context,
             ZweiDatabase::class.java
         ).build()
     }
@@ -33,7 +35,7 @@ class MountDaoTests {
         val newModel = generateMountModel(0)
         db.mountDao().insert(newModel)
 
-        Assert.assertTrue(db.mountDao().getAll().contains(newModel))
+        assertTrue(db.mountDao().getAll().contains(newModel))
     }
 
     @Test
@@ -45,12 +47,12 @@ class MountDaoTests {
         )
         db.mountDao().insertAll(models)
 
-        Assert.assertEquals(models, db.mountDao().getAll())
+        assertEquals(models, db.mountDao().getAll())
     }
 
     @Test
     fun findByIdWithNoMatchingMountsReturnsNull() {
-        Assert.assertNull(db.mountDao().findById(0))
+        assertNull(db.mountDao().findById(0))
     }
 
     @Test
@@ -63,17 +65,17 @@ class MountDaoTests {
         )
         db.mountDao().insertAll(models)
 
-        Assert.assertEquals(expectedModel, db.mountDao().findById(1))
+        assertEquals(expectedModel, db.mountDao().findById(1))
     }
 
     @Test
     fun getAllWithNoItemsReturnsEmptyList() {
-        Assert.assertTrue(db.mountDao().getAll().isEmpty())
+        assertTrue(db.mountDao().getAll().isEmpty())
     }
 
     @Test
     fun getAllWithIdsNoItemsReturnsEmptyList() {
-        Assert.assertTrue(db.mountDao().getAllByIds(listOf(0, 1, 2)).isEmpty())
+        assertTrue(db.mountDao().getAllByIds(listOf(0, 1, 2)).isEmpty())
     }
 
     @Test
@@ -84,7 +86,7 @@ class MountDaoTests {
             generateMountModel(2)
         )
         db.mountDao().insertAll(models)
-        Assert.assertTrue(db.mountDao().getAllByIds(listOf(0, 1, 3)).count() == 2)
+        assertTrue(db.mountDao().getAllByIds(listOf(0, 1, 3)).count() == 2)
     }
 
     @Test
@@ -95,7 +97,7 @@ class MountDaoTests {
             generateMountModel(2)
         )
         db.mountDao().insertAll(models)
-        Assert.assertEquals(models, db.mountDao().getAllByIds(listOf(0, 1, 2)))
+        assertEquals(models, db.mountDao().getAllByIds(listOf(0, 1, 2)))
     }
 
     private fun generateMountModel(

--- a/app/src/androidTest/java/com/chesire/zwei/room/dao/TitleDaoTests.kt
+++ b/app/src/androidTest/java/com/chesire/zwei/room/dao/TitleDaoTests.kt
@@ -1,12 +1,14 @@
 package com.chesire.zwei.room.dao
 
 import androidx.room.Room
-import androidx.test.InstrumentationRegistry
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import com.chesire.zwei.room.ZweiDatabase
 import com.chesire.zwei.xivapi.model.TitleModel
 import org.junit.After
-import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,7 +20,7 @@ class TitleDaoTests {
     @Before
     fun setup() {
         db = Room.inMemoryDatabaseBuilder(
-            InstrumentationRegistry.getContext(),
+            InstrumentationRegistry.getInstrumentation().context,
             ZweiDatabase::class.java
         ).build()
     }
@@ -33,7 +35,7 @@ class TitleDaoTests {
         val newModel = generateTitleModel(0)
         db.titleDao().insert(newModel)
 
-        Assert.assertTrue(db.titleDao().getAll().contains(newModel))
+        assertTrue(db.titleDao().getAll().contains(newModel))
     }
 
     @Test
@@ -45,12 +47,12 @@ class TitleDaoTests {
         )
         db.titleDao().insertAll(models)
 
-        Assert.assertEquals(models, db.titleDao().getAll())
+        assertEquals(models, db.titleDao().getAll())
     }
 
     @Test
     fun findByIdWithNoMatchingTitlesReturnsNull() {
-        Assert.assertNull(db.titleDao().findById(0))
+        assertNull(db.titleDao().findById(0))
     }
 
     @Test
@@ -63,17 +65,17 @@ class TitleDaoTests {
         )
         db.titleDao().insertAll(models)
 
-        Assert.assertEquals(expectedModel, db.titleDao().findById(1))
+        assertEquals(expectedModel, db.titleDao().findById(1))
     }
 
     @Test
     fun getAllWithNoItemsReturnsEmptyList() {
-        Assert.assertTrue(db.titleDao().getAll().isEmpty())
+        assertTrue(db.titleDao().getAll().isEmpty())
     }
 
     @Test
     fun getAllWithIdsNoItemsReturnsEmptyList() {
-        Assert.assertTrue(db.titleDao().getAllByIds(listOf(0, 1, 2)).isEmpty())
+        assertTrue(db.titleDao().getAllByIds(listOf(0, 1, 2)).isEmpty())
     }
 
     @Test
@@ -84,7 +86,7 @@ class TitleDaoTests {
             generateTitleModel(2)
         )
         db.titleDao().insertAll(models)
-        Assert.assertTrue(db.titleDao().getAllByIds(listOf(0, 1, 3)).count() == 2)
+        assertTrue(db.titleDao().getAllByIds(listOf(0, 1, 3)).count() == 2)
     }
 
     @Test
@@ -95,7 +97,7 @@ class TitleDaoTests {
             generateTitleModel(2)
         )
         db.titleDao().insertAll(models)
-        Assert.assertEquals(models, db.titleDao().getAllByIds(listOf(0, 1, 2)))
+        assertEquals(models, db.titleDao().getAllByIds(listOf(0, 1, 2)))
     }
 
     private fun generateTitleModel(

--- a/app/src/androidTest/java/com/chesire/zwei/view/PrimingTests.kt
+++ b/app/src/androidTest/java/com/chesire/zwei/view/PrimingTests.kt
@@ -3,8 +3,8 @@ package com.chesire.zwei.view
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
-import androidx.test.runner.AndroidJUnit4
 import com.chesire.zwei.dagger.espressoDaggerMockRule
 import com.chesire.zwei.util.PrefHelper
 import com.chesire.zwei.view.onboarding.OnboardingActivity

--- a/app/src/androidTest/java/com/chesire/zwei/view/onboarding/InitialTests.kt
+++ b/app/src/androidTest/java/com/chesire/zwei/view/onboarding/InitialTests.kt
@@ -1,14 +1,11 @@
 package com.chesire.zwei.view.onboarding
 
-import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
-import androidx.test.runner.AndroidJUnit4
 import com.chesire.zwei.R
 import com.chesire.zwei.dagger.espressoDaggerMockRule
 import com.chesire.zwei.util.PrefHelper
+import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed
 import com.schibsted.spain.barista.interaction.BaristaClickInteractions.clickOn
 import org.junit.Rule
 import org.junit.Test
@@ -30,14 +27,14 @@ class InitialTests {
     @Test
     fun initialApplicationStartLaunchesIntoWelcome() {
         activityRule.launchActivity(null)
-        onView(withId(R.id.textWelcome)).check(matches(ViewMatchers.isDisplayed()))
+        assertDisplayed(R.id.textWelcome)
     }
 
     @Test
     fun fromWelcomeCanNavigateToRequest() {
         activityRule.launchActivity(null)
         clickOn(R.id.buttonNext)
-        onView(withId(R.id.textRequest)).check(matches(ViewMatchers.isDisplayed()))
+        assertDisplayed(R.id.textRequest)
     }
 
     @Test
@@ -45,14 +42,14 @@ class InitialTests {
         activityRule.launchActivity(null)
         clickOn(R.id.buttonNext)
         clickOn(R.id.buttonNext)
-        onView(withId(R.id.editWorld)).check(matches(ViewMatchers.isDisplayed()))
+        assertDisplayed(R.id.editWorld)
     }
 
     @Test
     fun ifWelcomeIsDoneStartInRequest() {
         `when`(prefHelper.hasBypassedWelcome).thenReturn(true)
         activityRule.launchActivity(null)
-        onView(withId(R.id.textRequest)).check(matches(ViewMatchers.isDisplayed()))
+        assertDisplayed(R.id.textRequest)
     }
 
     @Test
@@ -60,6 +57,6 @@ class InitialTests {
         `when`(prefHelper.hasBypassedWelcome).thenReturn(true)
         `when`(prefHelper.hasBypassedRequest).thenReturn(true)
         activityRule.launchActivity(null)
-        onView(withId(R.id.editWorld)).check(matches(ViewMatchers.isDisplayed()))
+        assertDisplayed(R.id.editWorld)
     }
 }

--- a/app/src/main/java/com/chesire/zwei/util/PrefHelper.kt
+++ b/app/src/main/java/com/chesire/zwei/util/PrefHelper.kt
@@ -5,7 +5,6 @@ import android.content.SharedPreferences
 import com.chesire.zwei.R
 import dagger.Reusable
 import javax.inject.Inject
-import javax.inject.Singleton
 
 @Reusable
 class PrefHelper @Inject constructor(

--- a/app/src/main/java/com/chesire/zwei/util/PrefHelper.kt
+++ b/app/src/main/java/com/chesire/zwei/util/PrefHelper.kt
@@ -3,10 +3,11 @@ package com.chesire.zwei.util
 import android.content.Context
 import android.content.SharedPreferences
 import com.chesire.zwei.R
+import dagger.Reusable
 import javax.inject.Inject
 import javax.inject.Singleton
 
-@Singleton
+@Reusable
 class PrefHelper @Inject constructor(
     context: Context,
     private val sharedPreferences: SharedPreferences

--- a/app/src/test/java/com/chesire/zwei/room/converters/CollectionsConverterTests.kt
+++ b/app/src/test/java/com/chesire/zwei/room/converters/CollectionsConverterTests.kt
@@ -1,6 +1,6 @@
 package com.chesire.zwei.room.converters
 
-import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class CollectionsConverterTests {
@@ -13,7 +13,7 @@ class CollectionsConverterTests {
         val string3 = "string3"
 
         val jsonString = converter.fromListOfStringToString(listOf(string1, string2, string3))
-        Assert.assertEquals("[\"$string1\",\"$string2\",\"$string3\"]", jsonString)
+        assertEquals("[\"$string1\",\"$string2\",\"$string3\"]", jsonString)
     }
 
     @Test
@@ -24,7 +24,7 @@ class CollectionsConverterTests {
 
         val stringList =
             converter.fromStringToListOfString("[\"$string1\",\"$string2\",\"$string3\"]")
-        Assert.assertEquals(listOf(string1, string2, string3), stringList)
+        assertEquals(listOf(string1, string2, string3), stringList)
     }
 
     @Test
@@ -34,7 +34,7 @@ class CollectionsConverterTests {
         val int3 = 3
 
         val jsonString = converter.fromListOfIntToString(listOf(int1, int2, int3))
-        Assert.assertEquals("[1,2,3]", jsonString)
+        assertEquals("[1,2,3]", jsonString)
     }
 
     @Test
@@ -44,6 +44,6 @@ class CollectionsConverterTests {
         val int3 = 3
 
         val stringList = converter.fromStringToListOfInt("[1,2,3]")
-        Assert.assertEquals(listOf(int1, int2, int3), stringList)
+        assertEquals(listOf(int1, int2, int3), stringList)
     }
 }

--- a/app/src/test/java/com/chesire/zwei/room/converters/FreeCompanyEstateModelConverterTests.kt
+++ b/app/src/test/java/com/chesire/zwei/room/converters/FreeCompanyEstateModelConverterTests.kt
@@ -2,6 +2,7 @@ package com.chesire.zwei.room.converters
 
 import com.chesire.zwei.xivapi.model.FreeCompanyEstateModel
 import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class FreeCompanyEstateModelConverterTests {
@@ -15,11 +16,11 @@ class FreeCompanyEstateModelConverterTests {
 
     @Test
     fun `can convert FreeCompanyEstateModel into json string`() {
-        Assert.assertEquals(estateModelJson, converter.fromFreeCompanyEstateModel(estateModel))
+        assertEquals(estateModelJson, converter.fromFreeCompanyEstateModel(estateModel))
     }
 
     @Test
     fun `can convert json string into FreeCompanyEstateModel`() {
-        Assert.assertEquals(estateModel, converter.fromString(estateModelJson))
+        assertEquals(estateModel, converter.fromString(estateModelJson))
     }
 }

--- a/app/src/test/java/com/chesire/zwei/room/converters/FreeCompanyEstateModelConverterTests.kt
+++ b/app/src/test/java/com/chesire/zwei/room/converters/FreeCompanyEstateModelConverterTests.kt
@@ -1,7 +1,6 @@
 package com.chesire.zwei.room.converters
 
 import com.chesire.zwei.xivapi.model.FreeCompanyEstateModel
-import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Test
 

--- a/app/src/test/java/com/chesire/zwei/room/converters/GenderConverterTests.kt
+++ b/app/src/test/java/com/chesire/zwei/room/converters/GenderConverterTests.kt
@@ -1,7 +1,6 @@
 package com.chesire.zwei.room.converters
 
 import com.chesire.zwei.xivapi.flags.Gender
-import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Test
 

--- a/app/src/test/java/com/chesire/zwei/room/converters/GenderConverterTests.kt
+++ b/app/src/test/java/com/chesire/zwei/room/converters/GenderConverterTests.kt
@@ -2,6 +2,7 @@ package com.chesire.zwei.room.converters
 
 import com.chesire.zwei.xivapi.flags.Gender
 import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class GenderConverterTests {
@@ -9,11 +10,11 @@ class GenderConverterTests {
 
     @Test
     fun `can convert gender into int`() {
-        Assert.assertEquals(1, converter.fromGenderToInt(Gender.getGenderForValue(1)))
+        assertEquals(1, converter.fromGenderToInt(Gender.getGenderForValue(1)))
     }
 
     @Test
     fun `can convert int into gender`() {
-        Assert.assertEquals(Gender.getGenderForValue(1), converter.fromIntToGender(1))
+        assertEquals(Gender.getGenderForValue(1), converter.fromIntToGender(1))
     }
 }

--- a/app/src/test/java/com/chesire/zwei/room/converters/RaceConverterTests.kt
+++ b/app/src/test/java/com/chesire/zwei/room/converters/RaceConverterTests.kt
@@ -1,7 +1,7 @@
 package com.chesire.zwei.room.converters
 
 import com.chesire.zwei.xivapi.flags.Race
-import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class RaceConverterTests {
@@ -9,11 +9,11 @@ class RaceConverterTests {
 
     @Test
     fun `can convert race into int`() {
-        Assert.assertEquals(1, converter.fromRaceToInt(Race.getRaceForValue(1)))
+        assertEquals(1, converter.fromRaceToInt(Race.getRaceForValue(1)))
     }
 
     @Test
     fun `can convert int into race`() {
-        Assert.assertEquals(Race.getRaceForValue(1), converter.fromIntToRace(1))
+        assertEquals(Race.getRaceForValue(1), converter.fromIntToRace(1))
     }
 }

--- a/app/src/test/java/com/chesire/zwei/util/PrefHelperTests.kt
+++ b/app/src/test/java/com/chesire/zwei/util/PrefHelperTests.kt
@@ -3,9 +3,13 @@ package com.chesire.zwei.util
 import android.content.Context
 import android.content.SharedPreferences
 import com.chesire.zwei.R
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
-import org.junit.Assert
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Ignore
 import org.junit.Test
 
@@ -14,148 +18,161 @@ private const val bypassedRequest = "bypassedRequest"
 private const val acquiredCharacter = "acquiredCharacter"
 
 class PrefHelperTests {
-    private val mockContext = mock<Context> {
-        on { getString(R.string.key_bypassed_welcome) }.thenReturn(bypassedWelcome)
-        on { getString(R.string.key_bypassed_request) }.thenReturn(bypassedRequest)
-        on { getString(R.string.key_acquired_character) }.thenReturn(acquiredCharacter)
+    private val mockContext = mockk<Context> {
+        every { getString(R.string.key_bypassed_welcome) } returns bypassedWelcome
+        every { getString(R.string.key_bypassed_request) } returns bypassedRequest
+        every { getString(R.string.key_acquired_character) } returns acquiredCharacter
     }
 
     @Test
     fun `hasBypassedWelcome set() changes value in SharedPreferences`() {
-        val mockPrefEditor = mock<SharedPreferences.Editor> { }
-        val mockPreferences = mock<SharedPreferences> {
-            on { edit() }.thenReturn(mockPrefEditor)
+        val mockPrefEditor = mockk<SharedPreferences.Editor> {
+            every { putBoolean(bypassedWelcome, true) } returns this
+            every { apply() } just Runs
+        }
+        val mockPreferences = mockk<SharedPreferences> {
+            every { edit() } returns mockPrefEditor
         }
 
-        val classUnderTest = PrefHelper(mockContext, mockPreferences)
-        classUnderTest.hasBypassedWelcome = true
+        with(PrefHelper(mockContext, mockPreferences)) {
+            hasBypassedWelcome = true
+        }
 
-        verify(mockPrefEditor).putBoolean(bypassedWelcome, true)
+        verify { mockPrefEditor.putBoolean(bypassedWelcome, true) }
     }
 
     @Test
     fun `hasBypassedRequest set() changes value in SharedPreferences`() {
-        val mockPrefEditor = mock<SharedPreferences.Editor> { }
-        val mockPreferences = mock<SharedPreferences> {
-            on { edit() }.thenReturn(mockPrefEditor)
+        val mockPrefEditor = mockk<SharedPreferences.Editor> {
+            every { putBoolean(bypassedRequest, true) } returns this
+            every { apply() } just Runs
+        }
+        val mockPreferences = mockk<SharedPreferences> {
+            every { edit() } returns mockPrefEditor
         }
 
-        val classUnderTest = PrefHelper(mockContext, mockPreferences)
-        classUnderTest.hasBypassedRequest = true
+        with(PrefHelper(mockContext, mockPreferences)) {
+            hasBypassedRequest = true
+        }
 
-        verify(mockPrefEditor).putBoolean(bypassedRequest, true)
+        verify { mockPrefEditor.putBoolean(bypassedRequest, true) }
     }
 
     @Test
     fun `hasAcquiredCharacter set() changes value in SharedPreferences`() {
-        val mockPrefEditor = mock<SharedPreferences.Editor> { }
-        val mockPreferences = mock<SharedPreferences> {
-            on { edit() }.thenReturn(mockPrefEditor)
+        val mockPrefEditor = mockk<SharedPreferences.Editor> {
+            every { putBoolean(acquiredCharacter, true) } returns this
+            every { apply() } just Runs
+        }
+        val mockPreferences = mockk<SharedPreferences> {
+            every { edit() } returns mockPrefEditor
         }
 
-        val classUnderTest = PrefHelper(mockContext, mockPreferences)
-        classUnderTest.hasAcquiredCharacter = true
+        with(PrefHelper(mockContext, mockPreferences)) {
+            hasAcquiredCharacter = true
+        }
 
-        verify(mockPrefEditor).putBoolean(acquiredCharacter, true)
+        verify { mockPrefEditor.putBoolean(acquiredCharacter, true) }
     }
 
     @Test
     fun `shouldDisplayOnboarding returns true if have not bypassedWelcome`() {
-        val mockPrefEditor = mock<SharedPreferences.Editor> { }
-        val mockPreferences = mock<SharedPreferences> {
-            on { edit() }.thenReturn(mockPrefEditor)
-            on { getBoolean(bypassedWelcome, false) }.thenReturn(false)
-            on { getBoolean(bypassedRequest, false) }.thenReturn(true)
-            on { getBoolean(acquiredCharacter, false) }.thenReturn(true)
+        val mockPrefEditor = mockk<SharedPreferences.Editor> { }
+        val mockPreferences = mockk<SharedPreferences> {
+            every { edit() } returns mockPrefEditor
+            every { getBoolean(bypassedWelcome, false) } returns false
+            every { getBoolean(bypassedRequest, false) } returns true
+            every { getBoolean(acquiredCharacter, false) } returns true
         }
 
-        val classUnderTest = PrefHelper(mockContext, mockPreferences)
-
-        Assert.assertTrue(classUnderTest.shouldDisplayOnboarding)
+        with(PrefHelper(mockContext, mockPreferences)) {
+            assertTrue(shouldDisplayOnboarding)
+        }
     }
 
     @Test
     fun `shouldDisplayOnboarding returns true if have not bypassedRequest`() {
-        val mockPrefEditor = mock<SharedPreferences.Editor> { }
-        val mockPreferences = mock<SharedPreferences> {
-            on { edit() }.thenReturn(mockPrefEditor)
-            on { getBoolean(bypassedWelcome, false) }.thenReturn(true)
-            on { getBoolean(bypassedRequest, false) }.thenReturn(false)
-            on { getBoolean(acquiredCharacter, false) }.thenReturn(true)
+        val mockPrefEditor = mockk<SharedPreferences.Editor> { }
+        val mockPreferences = mockk<SharedPreferences> {
+            every { edit() } returns mockPrefEditor
+            every { getBoolean(bypassedWelcome, false) } returns true
+            every { getBoolean(bypassedRequest, false) } returns false
+            every { getBoolean(acquiredCharacter, false) } returns true
         }
 
-        val classUnderTest = PrefHelper(mockContext, mockPreferences)
-
-        Assert.assertTrue(classUnderTest.shouldDisplayOnboarding)
+        with(PrefHelper(mockContext, mockPreferences)) {
+            assertTrue(shouldDisplayOnboarding)
+        }
     }
 
     @Test
     fun `shouldDisplayOnboarding returns true if have not acquiredCharacter`() {
-        val mockPrefEditor = mock<SharedPreferences.Editor> { }
-        val mockPreferences = mock<SharedPreferences> {
-            on { edit() }.thenReturn(mockPrefEditor)
-            on { getBoolean(bypassedWelcome, false) }.thenReturn(true)
-            on { getBoolean(bypassedRequest, false) }.thenReturn(true)
-            on { getBoolean(acquiredCharacter, false) }.thenReturn(false)
+        val mockPrefEditor = mockk<SharedPreferences.Editor> { }
+        val mockPreferences = mockk<SharedPreferences> {
+            every { edit() } returns mockPrefEditor
+            every { getBoolean(bypassedWelcome, false) } returns true
+            every { getBoolean(bypassedRequest, false) } returns true
+            every { getBoolean(acquiredCharacter, false) } returns false
         }
 
-        val classUnderTest = PrefHelper(mockContext, mockPreferences)
-
-        Assert.assertTrue(classUnderTest.shouldDisplayOnboarding)
+        with(PrefHelper(mockContext, mockPreferences)) {
+            assertTrue(shouldDisplayOnboarding)
+        }
     }
 
     @Test
     fun `shouldDisplayOnboarding returns true if have not bypassedWelcome && bypassedRequest && acquiredCharacter`() {
-        val mockPrefEditor = mock<SharedPreferences.Editor> { }
-        val mockPreferences = mock<SharedPreferences> {
-            on { edit() }.thenReturn(mockPrefEditor)
-            on { getBoolean(bypassedWelcome, false) }.thenReturn(false)
-            on { getBoolean(bypassedRequest, false) }.thenReturn(false)
-            on { getBoolean(acquiredCharacter, false) }.thenReturn(false)
+        val mockPrefEditor = mockk<SharedPreferences.Editor> { }
+        val mockPreferences = mockk<SharedPreferences> {
+            every { edit() } returns mockPrefEditor
+            every { getBoolean(bypassedWelcome, false) } returns false
+            every { getBoolean(bypassedRequest, false) } returns false
+            every { getBoolean(acquiredCharacter, false) } returns false
         }
 
-        val classUnderTest = PrefHelper(mockContext, mockPreferences)
-
-        Assert.assertTrue(classUnderTest.shouldDisplayOnboarding)
+        with(PrefHelper(mockContext, mockPreferences)) {
+            assertTrue(shouldDisplayOnboarding)
+        }
     }
 
     @Test
     fun `shouldDisplayOnboarding returns false if have bypassedWelcome && bypassedRequest && acquiredCharacter`() {
-        val mockPrefEditor = mock<SharedPreferences.Editor> { }
-        val mockPreferences = mock<SharedPreferences> {
-            on { edit() }.thenReturn(mockPrefEditor)
-            on { getBoolean(bypassedWelcome, false) }.thenReturn(true)
-            on { getBoolean(bypassedRequest, false) }.thenReturn(true)
-            on { getBoolean(acquiredCharacter, false) }.thenReturn(true)
+        val mockPrefEditor = mockk<SharedPreferences.Editor> { }
+        val mockPreferences = mockk<SharedPreferences> {
+            every { edit() } returns mockPrefEditor
+            every { getBoolean(bypassedWelcome, false) } returns true
+            every { getBoolean(bypassedRequest, false) } returns true
+            every { getBoolean(acquiredCharacter, false) } returns true
         }
 
-        val classUnderTest = PrefHelper(mockContext, mockPreferences)
-
-        Assert.assertFalse(classUnderTest.shouldDisplayOnboarding)
+        with(PrefHelper(mockContext, mockPreferences)) {
+            assertFalse(shouldDisplayOnboarding)
+        }
     }
 
     @Test
     fun `calling clear clears shared preferences data`() {
-        val mockPrefEditor = mock<SharedPreferences.Editor> {
-            on { clear() }.thenReturn(mock)
+        val mockPrefEditor = mockk<SharedPreferences.Editor> {
+            every { clear() } returns this
+            every { apply() } just Runs
         }
-        val mockPreferences = mock<SharedPreferences> {
-            on { edit() }.thenReturn(mockPrefEditor)
+        val mockPreferences = mockk<SharedPreferences> {
+            every { edit() } returns mockPrefEditor
         }
 
-        val classUnderTest = PrefHelper(mockContext, mockPreferences)
+        with(PrefHelper(mockContext, mockPreferences)) {
+            clear()
+        }
 
-        classUnderTest.clear()
-
-        verify(mockPrefEditor).clear()
+        verify { mockPrefEditor.clear() }
     }
 
     @Test(expected = IllegalStateException::class)
     @Ignore("Can't test this for now, as using properties stops invalid data being passed in")
     fun `invalid data causes an IllegalStateException`() {
-        val mockPrefEditor = mock<SharedPreferences.Editor> { }
-        val mockPreferences = mock<SharedPreferences> {
-            on { edit() }.thenReturn(mockPrefEditor)
+        val mockPrefEditor = mockk<SharedPreferences.Editor> { }
+        val mockPreferences = mockk<SharedPreferences> {
+            every { edit() } returns mockPrefEditor
         }
 
         val classUnderTest = PrefHelper(mockContext, mockPreferences)

--- a/app/src/test/java/com/chesire/zwei/view/onboarding/OnboardingViewModelTests.kt
+++ b/app/src/test/java/com/chesire/zwei/view/onboarding/OnboardingViewModelTests.kt
@@ -12,11 +12,11 @@ import com.chesire.zwei.xivapi.model.CharacterDetailModel
 import com.chesire.zwei.xivapi.model.InfoModel
 import com.chesire.zwei.xivapi.model.SearchCharacterModel
 import com.chesire.zwei.xivapi.model.StateModel
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
+import io.mockk.every
+import io.mockk.mockk
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
@@ -27,10 +27,10 @@ class OnboardingViewModelTests {
 
     @Test
     fun `when searchForCharacter, with no name, set search status to error`() = runBlocking {
-        val mockApi = mock<XIVApi> {
-            on {
+        val mockApi = mockk<XIVApi> {
+            every {
                 searchForCharacter("Cheshire Cat", "Phoenix")
-            } doReturn async {
+            } returns async {
                 Resource.success(listOf(getSearchCharacterModel()))
             }
         }
@@ -41,15 +41,15 @@ class OnboardingViewModelTests {
 
         runBlocking { classUnderTest.searchForCharacter() }.join()
 
-        Assert.assertEquals(Status.Error, classUnderTest.searchStatus.value)
+        assertEquals(Status.Error, classUnderTest.searchStatus.value)
     }
 
     @Test
     fun `when searchForCharacter, with no world, set search status to error`() = runBlocking {
-        val mockApi = mock<XIVApi> {
-            on {
+        val mockApi = mockk<XIVApi> {
+            every {
                 searchForCharacter("Cheshire Cat", "Phoenix")
-            } doReturn async {
+            } returns async {
                 Resource.success(listOf(getSearchCharacterModel()))
             }
         }
@@ -60,16 +60,16 @@ class OnboardingViewModelTests {
 
         runBlocking { classUnderTest.searchForCharacter() }.join()
 
-        Assert.assertEquals(Status.Error, classUnderTest.searchStatus.value)
+        assertEquals(Status.Error, classUnderTest.searchStatus.value)
     }
 
     @Test
     fun `when searchForCharacter fails, set search status to error`() = runBlocking {
-        val mockApi = mock<XIVApi> {
-            on {
+        val mockApi = mockk<XIVApi> {
+            every {
                 searchForCharacter("Cheshire Cat", "Phoenix")
-            } doReturn async {
-                Resource.error<List<SearchCharacterModel>>("Test", mock {})
+            } returns async {
+                Resource.error<List<SearchCharacterModel>>("Test", mockk())
             }
         }
 
@@ -80,16 +80,16 @@ class OnboardingViewModelTests {
 
         runBlocking { classUnderTest.searchForCharacter() }.join()
 
-        Assert.assertEquals(Status.Error, classUnderTest.searchStatus.value)
+        assertEquals(Status.Error, classUnderTest.searchStatus.value)
     }
 
     @Test
     fun `when searchForCharacter succeeds, with no characters, set search status to error`() =
         runBlocking {
-            val mockApi = mock<XIVApi> {
-                on {
+            val mockApi = mockk<XIVApi> {
+                every {
                     searchForCharacter("Cheshire Cat", "Phoenix")
-                } doReturn async {
+                } returns async {
                     Resource.success<List<SearchCharacterModel>>(emptyList())
                 }
             }
@@ -101,16 +101,16 @@ class OnboardingViewModelTests {
 
             runBlocking { classUnderTest.searchForCharacter() }.join()
 
-            Assert.assertEquals(Status.Error, classUnderTest.searchStatus.value)
+            assertEquals(Status.Error, classUnderTest.searchStatus.value)
         }
 
     @Test
     fun `when searchForCharacter succeeds, with characters, set search status to success`() =
         runBlocking {
-            val mockApi = mock<XIVApi> {
-                on {
+            val mockApi = mockk<XIVApi> {
+                every {
                     searchForCharacter("Cheshire Cat", "Phoenix")
-                } doReturn async {
+                } returns async {
                     Resource.success(listOf(getSearchCharacterModel()))
                 }
             }
@@ -122,17 +122,17 @@ class OnboardingViewModelTests {
 
             runBlocking { classUnderTest.searchForCharacter() }.join()
 
-            Assert.assertEquals(Status.Success, classUnderTest.searchStatus.value)
+            assertEquals(Status.Success, classUnderTest.searchStatus.value)
         }
 
     @Test
     fun `when searchForCharacter succeeds, with characters, populate the foundCharacters`() =
         runBlocking {
             val expectedCharacters = listOf(getSearchCharacterModel())
-            val mockApi = mock<XIVApi> {
-                on {
+            val mockApi = mockk<XIVApi> {
+                every {
                     searchForCharacter("Cheshire Cat", "Phoenix")
-                } doReturn async {
+                } returns async {
                     Resource.success(expectedCharacters)
                 }
             }
@@ -144,17 +144,17 @@ class OnboardingViewModelTests {
 
             runBlocking { classUnderTest.searchForCharacter() }.join()
 
-            Assert.assertEquals(expectedCharacters, classUnderTest.foundCharacters.value)
+            assertEquals(expectedCharacters, classUnderTest.foundCharacters.value)
         }
 
     @Test
     fun `when searchForCharacter succeeds, with characters, set the current character to the first found`() =
         runBlocking {
             val expectedCharacters = listOf(getSearchCharacterModel(0), getSearchCharacterModel(1))
-            val mockApi = mock<XIVApi> {
-                on {
+            val mockApi = mockk<XIVApi> {
+                every {
                     searchForCharacter("Cheshire Cat", "Phoenix")
-                } doReturn async {
+                } returns async {
                     Resource.success(expectedCharacters)
                 }
             }
@@ -166,16 +166,16 @@ class OnboardingViewModelTests {
 
             runBlocking { classUnderTest.searchForCharacter() }.join()
 
-            Assert.assertEquals(expectedCharacters.first(), classUnderTest.currentCharacter.value)
+            assertEquals(expectedCharacters.first(), classUnderTest.currentCharacter.value)
         }
 
     @Test
     fun `when getCharacter, with no current character, set get character status to error`() =
         runBlocking {
-            val mockApi = mock<XIVApi> {
-                on {
+            val mockApi = mockk<XIVApi> {
+                every {
                     getCharacter(0)
-                } doReturn async {
+                } returns async {
                     Resource.success(getCharacterDetailModel())
                 }
             }
@@ -187,16 +187,16 @@ class OnboardingViewModelTests {
 
             runBlocking { classUnderTest.getCharacter() }.join()
 
-            Assert.assertEquals(GetCharacterStatus.Error, classUnderTest.getCharacterStatus.value)
+            assertEquals(GetCharacterStatus.Error, classUnderTest.getCharacterStatus.value)
         }
 
     @Test
     fun `when getCharacter fails, set get character status to error`() = runBlocking {
-        val mockApi = mock<XIVApi> {
-            on {
+        val mockApi = mockk<XIVApi> {
+            every {
                 getCharacter(0)
-            } doReturn async {
-                Resource.error<Resource<Any>>("test", mock {})
+            } returns async {
+                Resource.error<Resource<Any>>("test", mockk())
             }
         }
 
@@ -208,17 +208,17 @@ class OnboardingViewModelTests {
 
         runBlocking { classUnderTest.getCharacter() }.join()
 
-        Assert.assertEquals(GetCharacterStatus.Error, classUnderTest.getCharacterStatus.value)
+        assertEquals(GetCharacterStatus.Error, classUnderTest.getCharacterStatus.value)
     }
 
     @Test
     fun `when getCharacter reports unexpected branch, set get character status to error`() =
         runBlocking {
-            val mockApi = mock<XIVApi> {
-                on {
+            val mockApi = mockk<XIVApi> {
+                every {
                     getCharacter(0)
-                } doReturn async {
-                    Resource.loading<Resource<Any>>(mock {})
+                } returns async {
+                    Resource.loading<Resource<Any>>(mockk())
                 }
             }
 
@@ -230,16 +230,16 @@ class OnboardingViewModelTests {
 
             runBlocking { classUnderTest.getCharacter() }.join()
 
-            Assert.assertEquals(GetCharacterStatus.Error, classUnderTest.getCharacterStatus.value)
+            assertEquals(GetCharacterStatus.Error, classUnderTest.getCharacterStatus.value)
         }
 
     @Test
     fun `when getCharacter succeeds, with InfoModel, set get character status to GotInfo`() =
         runBlocking {
-            val mockApi = mock<XIVApi> {
-                on {
+            val mockApi = mockk<XIVApi> {
+                every {
                     getCharacter(0)
-                } doReturn async {
+                } returns async {
                     Resource.success(getInfoModel())
                 }
             }
@@ -252,16 +252,16 @@ class OnboardingViewModelTests {
 
             runBlocking { classUnderTest.getCharacter() }.join()
 
-            Assert.assertEquals(GetCharacterStatus.GotInfo, classUnderTest.getCharacterStatus.value)
+            assertEquals(GetCharacterStatus.GotInfo, classUnderTest.getCharacterStatus.value)
         }
 
     @Test
     fun `when getCharacter succeeds, with CharacterDetailModel, set get character status to GotCharacter`() =
         runBlocking {
-            val mockApi = mock<XIVApi> {
-                on {
+            val mockApi = mockk<XIVApi> {
+                every {
                     getCharacter(0)
-                } doReturn async {
+                } returns async {
                     Resource.success(getCharacterDetailModel())
                 }
             }
@@ -274,10 +274,7 @@ class OnboardingViewModelTests {
 
             runBlocking { classUnderTest.getCharacter() }.join()
 
-            Assert.assertEquals(
-                GetCharacterStatus.GotCharacter,
-                classUnderTest.getCharacterStatus.value
-            )
+            assertEquals(GetCharacterStatus.GotCharacter, classUnderTest.getCharacterStatus.value)
         }
 
     private fun getSearchCharacterModel(id: Int = 0): SearchCharacterModel {

--- a/app/src/test/java/com/chesire/zwei/xivapi/adapters/GenderAdapterTests.kt
+++ b/app/src/test/java/com/chesire/zwei/xivapi/adapters/GenderAdapterTests.kt
@@ -3,7 +3,7 @@ package com.chesire.zwei.xivapi.adapters
 import com.chesire.zwei.xivapi.flags.Gender
 import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.Moshi
-import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class GenderAdapterTests {
@@ -14,22 +14,22 @@ class GenderAdapterTests {
 
     @Test
     fun `Moshi converts 'Male' to '1'`() {
-        Assert.assertEquals("1", moshiAdapter.toJson(Gender.Male))
+        assertEquals("1", moshiAdapter.toJson(Gender.Male))
     }
 
     @Test
     fun `Moshi converts 'Female' to '2'`() {
-        Assert.assertEquals("2", moshiAdapter.toJson(Gender.Female))
+        assertEquals("2", moshiAdapter.toJson(Gender.Female))
     }
 
     @Test
     fun `Moshi converts '1' to 'Male'`() {
-        Assert.assertEquals(Gender.Male, moshiAdapter.fromJson("1"))
+        assertEquals(Gender.Male, moshiAdapter.fromJson("1"))
     }
 
     @Test
     fun `Moshi converts '2' to 'Female'`() {
-        Assert.assertEquals(Gender.Female, moshiAdapter.fromJson("2"))
+        assertEquals(Gender.Female, moshiAdapter.fromJson("2"))
     }
 
     @Test(expected = JsonDataException::class)

--- a/app/src/test/java/com/chesire/zwei/xivapi/adapters/RaceAdapterTests.kt
+++ b/app/src/test/java/com/chesire/zwei/xivapi/adapters/RaceAdapterTests.kt
@@ -3,7 +3,7 @@ package com.chesire.zwei.xivapi.adapters
 import com.chesire.zwei.xivapi.flags.Race
 import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.Moshi
-import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class RaceAdapterTests {
@@ -15,122 +15,122 @@ class RaceAdapterTests {
 
     @Test
     fun `'Hyur' toJson produces value '1'`() {
-        Assert.assertEquals(1, raceAdapter.toJson(Race.Hyur))
+        assertEquals(1, raceAdapter.toJson(Race.Hyur))
     }
 
     @Test
     fun `'Elezen' toJson produces value '2'`() {
-        Assert.assertEquals(2, raceAdapter.toJson(Race.Elezen))
+        assertEquals(2, raceAdapter.toJson(Race.Elezen))
     }
 
     @Test
     fun `'Lalafell' toJson produces value '3'`() {
-        Assert.assertEquals(3, raceAdapter.toJson(Race.Lalafell))
+        assertEquals(3, raceAdapter.toJson(Race.Lalafell))
     }
 
     @Test
     fun `'Miqote' toJson produces value '4'`() {
-        Assert.assertEquals(4, raceAdapter.toJson(Race.Miqote))
+        assertEquals(4, raceAdapter.toJson(Race.Miqote))
     }
 
     @Test
     fun `'Roegadyn' toJson produces value '5'`() {
-        Assert.assertEquals(5, raceAdapter.toJson(Race.Roegadyn))
+        assertEquals(5, raceAdapter.toJson(Race.Roegadyn))
     }
 
     @Test
     fun `'AuRa' toJson produces value '6'`() {
-        Assert.assertEquals(6, raceAdapter.toJson(Race.AuRa))
+        assertEquals(6, raceAdapter.toJson(Race.AuRa))
     }
 
     @Test
     fun `Moshi with adapter converts 'Hyur' to '1'`() {
-        Assert.assertEquals("1", moshiAdapter.toJson(Race.Hyur))
+        assertEquals("1", moshiAdapter.toJson(Race.Hyur))
     }
 
     @Test
     fun `Moshi with adapter converts 'Elezen' to '2'`() {
-        Assert.assertEquals("2", moshiAdapter.toJson(Race.Elezen))
+        assertEquals("2", moshiAdapter.toJson(Race.Elezen))
     }
 
     @Test
     fun `Moshi with adapter converts 'Lalafell' to '3'`() {
-        Assert.assertEquals("3", moshiAdapter.toJson(Race.Lalafell))
+        assertEquals("3", moshiAdapter.toJson(Race.Lalafell))
     }
 
     @Test
     fun `Moshi with adapter converts 'Miqote' to '4'`() {
-        Assert.assertEquals("4", moshiAdapter.toJson(Race.Miqote))
+        assertEquals("4", moshiAdapter.toJson(Race.Miqote))
     }
 
     @Test
     fun `Moshi with adapter converts 'Roegadyn' to '5'`() {
-        Assert.assertEquals("5", moshiAdapter.toJson(Race.Roegadyn))
+        assertEquals("5", moshiAdapter.toJson(Race.Roegadyn))
     }
 
     @Test
     fun `Moshi with adapter converts 'AuRa' to '6'`() {
-        Assert.assertEquals("6", moshiAdapter.toJson(Race.AuRa))
+        assertEquals("6", moshiAdapter.toJson(Race.AuRa))
     }
 
     @Test
     fun `'1' fromJson produces Race 'Hyur'`() {
-        Assert.assertEquals(Race.Hyur, raceAdapter.fromJson(1))
+        assertEquals(Race.Hyur, raceAdapter.fromJson(1))
     }
 
     @Test
     fun `'2' fromJson produces Race 'Elezen'`() {
-        Assert.assertEquals(Race.Elezen, raceAdapter.fromJson(2))
+        assertEquals(Race.Elezen, raceAdapter.fromJson(2))
     }
 
     @Test
     fun `'3' fromJson produces Race 'Lalafell'`() {
-        Assert.assertEquals(Race.Lalafell, raceAdapter.fromJson(3))
+        assertEquals(Race.Lalafell, raceAdapter.fromJson(3))
     }
 
     @Test
     fun `'4' fromJson produces Race 'Miqote'`() {
-        Assert.assertEquals(Race.Miqote, raceAdapter.fromJson(4))
+        assertEquals(Race.Miqote, raceAdapter.fromJson(4))
     }
 
     @Test
     fun `'5' fromJson produces Race 'Roegadyn'`() {
-        Assert.assertEquals(Race.Roegadyn, raceAdapter.fromJson(5))
+        assertEquals(Race.Roegadyn, raceAdapter.fromJson(5))
     }
 
     @Test
     fun `'6' fromJson produces Race 'AuRa'`() {
-        Assert.assertEquals(Race.AuRa, raceAdapter.fromJson(6))
+        assertEquals(Race.AuRa, raceAdapter.fromJson(6))
     }
 
     @Test
     fun `Moshi with adapter converts '1' to 'Hyur'`() {
-        Assert.assertEquals(Race.Hyur, moshiAdapter.fromJson("1"))
+        assertEquals(Race.Hyur, moshiAdapter.fromJson("1"))
     }
 
     @Test
     fun `Moshi with adapter converts '2' to 'Elezen'`() {
-        Assert.assertEquals(Race.Elezen, moshiAdapter.fromJson("2"))
+        assertEquals(Race.Elezen, moshiAdapter.fromJson("2"))
     }
 
     @Test
     fun `Moshi with adapter converts '3' to 'Lalafell'`() {
-        Assert.assertEquals(Race.Lalafell, moshiAdapter.fromJson("3"))
+        assertEquals(Race.Lalafell, moshiAdapter.fromJson("3"))
     }
 
     @Test
     fun `Moshi with adapter converts '4' to 'Miqote'`() {
-        Assert.assertEquals(Race.Miqote, moshiAdapter.fromJson("4"))
+        assertEquals(Race.Miqote, moshiAdapter.fromJson("4"))
     }
 
     @Test
     fun `Moshi with adapter converts '5' to 'Roegadyn'`() {
-        Assert.assertEquals(Race.Roegadyn, moshiAdapter.fromJson("5"))
+        assertEquals(Race.Roegadyn, moshiAdapter.fromJson("5"))
     }
 
     @Test
     fun `Moshi with adapter converts '6' to 'AuRa'`() {
-        Assert.assertEquals(Race.AuRa, moshiAdapter.fromJson("6"))
+        assertEquals(Race.AuRa, moshiAdapter.fromJson("6"))
     }
 
     @Test(expected = JsonDataException::class)

--- a/app/src/test/java/com/chesire/zwei/xivapi/adapters/StateAdapterTests.kt
+++ b/app/src/test/java/com/chesire/zwei/xivapi/adapters/StateAdapterTests.kt
@@ -3,7 +3,7 @@ package com.chesire.zwei.xivapi.adapters
 import com.chesire.zwei.xivapi.flags.State
 import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.Moshi
-import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class StateAdapterTests {
@@ -15,122 +15,122 @@ class StateAdapterTests {
 
     @Test
     fun `'None' toJson produces '0'`() {
-        Assert.assertEquals(0, stateAdapter.toJson(State.None))
+        assertEquals(0, stateAdapter.toJson(State.None))
     }
 
     @Test
     fun `'Adding' toJson produces '1'`() {
-        Assert.assertEquals(1, stateAdapter.toJson(State.Adding))
+        assertEquals(1, stateAdapter.toJson(State.Adding))
     }
 
     @Test
     fun `'Cached' toJson produces '2'`() {
-        Assert.assertEquals(2, stateAdapter.toJson(State.Cached))
+        assertEquals(2, stateAdapter.toJson(State.Cached))
     }
 
     @Test
     fun `'NotFound' toJson produces '3'`() {
-        Assert.assertEquals(3, stateAdapter.toJson(State.NotFound))
+        assertEquals(3, stateAdapter.toJson(State.NotFound))
     }
 
     @Test
     fun `'Blacklist' toJson produces '4'`() {
-        Assert.assertEquals(4, stateAdapter.toJson(State.Blacklist))
+        assertEquals(4, stateAdapter.toJson(State.Blacklist))
     }
 
     @Test
     fun `'Private' toJson produces '5'`() {
-        Assert.assertEquals(5, stateAdapter.toJson(State.Private))
+        assertEquals(5, stateAdapter.toJson(State.Private))
     }
 
     @Test
     fun `Moshi with adapter converts 'None' to '0'`() {
-        Assert.assertEquals("0", moshiAdapter.toJson(State.None))
+        assertEquals("0", moshiAdapter.toJson(State.None))
     }
 
     @Test
     fun `Moshi with adapter converts 'Adding' to '1'`() {
-        Assert.assertEquals("1", moshiAdapter.toJson(State.Adding))
+        assertEquals("1", moshiAdapter.toJson(State.Adding))
     }
 
     @Test
     fun `Moshi with adapter converts 'Cached' to '2'`() {
-        Assert.assertEquals("2", moshiAdapter.toJson(State.Cached))
+        assertEquals("2", moshiAdapter.toJson(State.Cached))
     }
 
     @Test
     fun `Moshi with adapter converts 'NotFound' to '3'`() {
-        Assert.assertEquals("3", moshiAdapter.toJson(State.NotFound))
+        assertEquals("3", moshiAdapter.toJson(State.NotFound))
     }
 
     @Test
     fun `Moshi with adapter converts 'Blacklist' to '4'`() {
-        Assert.assertEquals("4", moshiAdapter.toJson(State.Blacklist))
+        assertEquals("4", moshiAdapter.toJson(State.Blacklist))
     }
 
     @Test
     fun `Moshi with adapter converts 'Private' to '5'`() {
-        Assert.assertEquals("5", moshiAdapter.toJson(State.Private))
+        assertEquals("5", moshiAdapter.toJson(State.Private))
     }
 
     @Test
     fun `'0' fromJson produces State 'None'`() {
-        Assert.assertEquals(stateAdapter.fromJson(0), State.None)
+        assertEquals(stateAdapter.fromJson(0), State.None)
     }
 
     @Test
     fun `'1' fromJson produces State 'Adding'`() {
-        Assert.assertEquals(stateAdapter.fromJson(1), State.Adding)
+        assertEquals(stateAdapter.fromJson(1), State.Adding)
     }
 
     @Test
     fun `'2' fromJson produces State 'Cached'`() {
-        Assert.assertEquals(stateAdapter.fromJson(2), State.Cached)
+        assertEquals(stateAdapter.fromJson(2), State.Cached)
     }
 
     @Test
     fun `'3' fromJson produces State 'NotFound'`() {
-        Assert.assertEquals(stateAdapter.fromJson(3), State.NotFound)
+        assertEquals(stateAdapter.fromJson(3), State.NotFound)
     }
 
     @Test
     fun `'4' fromJson produces State 'Blacklist'`() {
-        Assert.assertEquals(stateAdapter.fromJson(4), State.Blacklist)
+        assertEquals(stateAdapter.fromJson(4), State.Blacklist)
     }
 
     @Test
     fun `'5' fromJson produces State 'Private'`() {
-        Assert.assertEquals(stateAdapter.fromJson(5), State.Private)
+        assertEquals(stateAdapter.fromJson(5), State.Private)
     }
 
     @Test
     fun `Moshi was adapter converts '0' to 'None'`() {
-        Assert.assertEquals(moshiAdapter.fromJson("0"), State.None)
+        assertEquals(moshiAdapter.fromJson("0"), State.None)
     }
 
     @Test
     fun `Moshi was adapter converts '1' to 'Adding'`() {
-        Assert.assertEquals(moshiAdapter.fromJson("1"), State.Adding)
+        assertEquals(moshiAdapter.fromJson("1"), State.Adding)
     }
 
     @Test
     fun `Moshi was adapter converts '2' to 'Cached'`() {
-        Assert.assertEquals(moshiAdapter.fromJson("2"), State.Cached)
+        assertEquals(moshiAdapter.fromJson("2"), State.Cached)
     }
 
     @Test
     fun `Moshi was adapter converts '3' to 'NotFound'`() {
-        Assert.assertEquals(moshiAdapter.fromJson("3"), State.NotFound)
+        assertEquals(moshiAdapter.fromJson("3"), State.NotFound)
     }
 
     @Test
     fun `Moshi was adapter converts '4' to 'Blacklist'`() {
-        Assert.assertEquals(moshiAdapter.fromJson("4"), State.Blacklist)
+        assertEquals(moshiAdapter.fromJson("4"), State.Blacklist)
     }
 
     @Test
     fun `Moshi was adapter converts '5' to 'Private'`() {
-        Assert.assertEquals(moshiAdapter.fromJson("5"), State.Private)
+        assertEquals(moshiAdapter.fromJson("5"), State.Private)
     }
 
     @Test(expected = JsonDataException::class)

--- a/app/src/test/java/com/chesire/zwei/xivapi/flags/GenderTests.kt
+++ b/app/src/test/java/com/chesire/zwei/xivapi/flags/GenderTests.kt
@@ -1,26 +1,26 @@
 package com.chesire.zwei.xivapi.flags
 
-import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class GenderTests {
     @Test
     fun `getGenderForValue with '0' returns 'Unknown'`() {
-        Assert.assertEquals(Gender.Unknown, Gender.getGenderForValue(0))
+        assertEquals(Gender.Unknown, Gender.getGenderForValue(0))
     }
 
     @Test
     fun `getGenderForValue with '99' returns 'Unknown'`() {
-        Assert.assertEquals(Gender.Unknown, Gender.getGenderForValue(99))
+        assertEquals(Gender.Unknown, Gender.getGenderForValue(99))
     }
 
     @Test
     fun `getGenderForValue with '1' returns 'Male'`() {
-        Assert.assertEquals(Gender.Male, Gender.getGenderForValue(1))
+        assertEquals(Gender.Male, Gender.getGenderForValue(1))
     }
 
     @Test
     fun `getGenderForValue with '2' returns 'Female'`() {
-        Assert.assertEquals(Gender.Female, Gender.getGenderForValue(2))
+        assertEquals(Gender.Female, Gender.getGenderForValue(2))
     }
 }

--- a/app/src/test/java/com/chesire/zwei/xivapi/flags/RaceTests.kt
+++ b/app/src/test/java/com/chesire/zwei/xivapi/flags/RaceTests.kt
@@ -1,46 +1,46 @@
 package com.chesire.zwei.xivapi.flags
 
-import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class RaceTests {
     @Test
     fun `getRaceForValue with '0' returns 'Unknown'`() {
-        Assert.assertEquals(Race.Unknown, Race.getRaceForValue(0))
+        assertEquals(Race.Unknown, Race.getRaceForValue(0))
     }
 
     @Test
     fun `getRaceForValue with '99' returns 'Unknown'`() {
-        Assert.assertEquals(Race.Unknown, Race.getRaceForValue(99))
+        assertEquals(Race.Unknown, Race.getRaceForValue(99))
     }
 
     @Test
     fun `getRaceForValue with '1' returns 'Hyur'`() {
-        Assert.assertEquals(Race.Hyur, Race.getRaceForValue(1))
+        assertEquals(Race.Hyur, Race.getRaceForValue(1))
     }
 
     @Test
     fun `getRaceForValue with '2' returns 'Elezen'`() {
-        Assert.assertEquals(Race.Elezen, Race.getRaceForValue(2))
+        assertEquals(Race.Elezen, Race.getRaceForValue(2))
     }
 
     @Test
     fun `getRaceForValue with '3' returns 'Lalafell'`() {
-        Assert.assertEquals(Race.Lalafell, Race.getRaceForValue(3))
+        assertEquals(Race.Lalafell, Race.getRaceForValue(3))
     }
 
     @Test
     fun `getRaceForValue with '4' returns 'Miqote'`() {
-        Assert.assertEquals(Race.Miqote, Race.getRaceForValue(4))
+        assertEquals(Race.Miqote, Race.getRaceForValue(4))
     }
 
     @Test
     fun `getRaceForValue with '5' returns 'Roegadyn'`() {
-        Assert.assertEquals(Race.Roegadyn, Race.getRaceForValue(5))
+        assertEquals(Race.Roegadyn, Race.getRaceForValue(5))
     }
 
     @Test
     fun `getRaceForValue with '6' returns 'AuRa'`() {
-        Assert.assertEquals(Race.AuRa, Race.getRaceForValue(6))
+        assertEquals(Race.AuRa, Race.getRaceForValue(6))
     }
 }

--- a/app/src/test/java/com/chesire/zwei/xivapi/interceptors/InterceptorOverrideTests.kt
+++ b/app/src/test/java/com/chesire/zwei/xivapi/interceptors/InterceptorOverrideTests.kt
@@ -5,7 +5,7 @@ import okhttp3.Request
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
-import org.junit.Assert
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -30,7 +30,7 @@ class InterceptorOverrideTests {
         sendMockRequest(okHttp)
         val request = mockWebServer.takeRequest()
 
-        Assert.assertTrue(request.path.contains("key=0123456789abcdef"))
+        assertTrue(request.path.contains("key=0123456789abcdef"))
     }
 
     private fun getOkHttpClient(key: String, value: String): OkHttpClient {

--- a/app/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/app/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline


### PR DESCRIPTION
Change from using mockito-kotlin to mockk.

Mockk has been added to `androidTest` but is not really being used, hopefully DaggerMock will update to allow Mockk use instead of mockito. Failing that I should refactor the tests to work with Mockk.